### PR TITLE
feature/sc 36967/cxxwrap richdem final

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,8 @@ add_library(richdem
 )
 
 add_library(jlrichdem
-  src/jlrichdem/common/jlcommon.cpp)
+  src/jlrichdem/common/jlcommon.cpp
+  src/jlrichdem/misc/jlmisc.cpp)
 
 # set_target_properties(richdem PROPERTIES VERSION ${PROJECT_VERSION})
 # set_target_properties(richdem PROPERTIES SOVERSION 2)

--- a/julia/richdem/src/richdem.jl
+++ b/julia/richdem/src/richdem.jl
@@ -14,4 +14,13 @@ module common
     Base.IndexStyle(::Type{<:Array2D}) = IndexCartesian()
 end #common
 
+module misc
+    using CxxWrap
+    @wrapmodule("/workspaces/richdem/build/lib/libjlrichdem.so", :define_misc_module)
+
+    function __init()
+        @initcxx
+    end
+end #misc
+
 end # module richdem

--- a/julia/richdem/src/richdem.jl
+++ b/julia/richdem/src/richdem.jl
@@ -18,7 +18,7 @@ module misc
     using CxxWrap
     @wrapmodule("/workspaces/richdem/build/lib/libjlrichdem.so", :define_misc_module)
 
-    function __init()
+    function __init__()
         @initcxx
     end
 end #misc

--- a/src/jlrichdem/common/jlcommon.cpp
+++ b/src/jlrichdem/common/jlcommon.cpp
@@ -23,6 +23,7 @@ namespace jlrichdem
             wrapped.method("height", &WrappedT::height);
             wrapped.method("numDataCells", &WrappedT::numDataCells);
             wrapped.method("saveGDAL", &WrappedT::saveGDAL);
+            wrapped.method("noData", &WrappedT::noData);
             wrapped.method("get_projection", [](const WrappedT &mat)
                            { return mat.projection; });
             wrapped.method("isNoData", [](WrappedT &mat, xyT x, xyT y)

--- a/src/jlrichdem/common/jlcommon.cpp
+++ b/src/jlrichdem/common/jlcommon.cpp
@@ -59,5 +59,5 @@ JLCXX_MODULE define_julia_module(jlcxx::Module &mod)
     mod.set_const("D4", rd::Topology::D4);
     mod.set_const("D8", rd::Topology::D8);
     mod.add_type<Parametric<TypeVar<1>>>("Array2D", jlcxx::julia_type("AbstractMatrix"))
-        .apply<rd::Array2D<float>, rd::Array2D<rd::flowdir_t>, rd::Array2D<rd::dephier::dh_label_t>>(jlrichdem::WrapArray2D());
+        .apply<rd::Array2D<double>, rd::Array2D<float>, rd::Array2D<rd::flowdir_t>, rd::Array2D<rd::dephier::dh_label_t>>(jlrichdem::WrapArray2D());
 }

--- a/src/jlrichdem/common/jlcommon.cpp
+++ b/src/jlrichdem/common/jlcommon.cpp
@@ -28,7 +28,7 @@ namespace jlrichdem
             wrapped.method("isNoData", [](WrappedT &mat, xyT x, xyT y)
                            { return mat.isNoData(x, y); });
             wrapped.method("setNoData", [](WrappedT &mat, const ScalarT &ndval)
-                           { return mat.setNoData(ndval);});
+                           { return mat.setNoData(ndval); });
 
             // Overloading functions from julia base module.
             wrapped.module()
@@ -57,6 +57,8 @@ JLCXX_MODULE define_julia_module(jlcxx::Module &mod)
     using jlcxx::Parametric;
     using jlcxx::TypeVar;
     mod.add_bits<int32_t>("xy_t");
+    mod.add_bits<rd::flowdir_t>("flowdir_t");
+    mod.add_bits<rd::dephier::dh_label_t>("dh_label_t");
     mod.add_bits<rd::Topology>("Topology", jlcxx::julia_type("CppEnum"));
     mod.set_const("D4", rd::Topology::D4);
     mod.set_const("D8", rd::Topology::D8);

--- a/src/jlrichdem/common/jlcommon.cpp
+++ b/src/jlrichdem/common/jlcommon.cpp
@@ -29,6 +29,8 @@ namespace jlrichdem
                            { return mat.isNoData(x, y); });
             wrapped.method("setNoData", [](WrappedT &mat, const ScalarT &ndval)
                            { return mat.setNoData(ndval); });
+            wrapped.method("resize", [](WrappedT &mat, const xyT width, const xyT height, const ScalarT &val)
+                           { return mat.resize(width, height, val); });
 
             // Overloading functions from julia base module.
             wrapped.module()

--- a/src/jlrichdem/common/jlcommon.cpp
+++ b/src/jlrichdem/common/jlcommon.cpp
@@ -27,6 +27,8 @@ namespace jlrichdem
                            { return mat.projection; });
             wrapped.method("isNoData", [](WrappedT &mat, xyT x, xyT y)
                            { return mat.isNoData(x, y); });
+            wrapped.method("setNoData", [](WrappedT &mat, const ScalarT &ndval)
+                           { return mat.setNoData(ndval);});
 
             // Overloading functions from julia base module.
             wrapped.module()

--- a/src/jlrichdem/misc/jlmisc.cpp
+++ b/src/jlrichdem/misc/jlmisc.cpp
@@ -1,0 +1,17 @@
+#include <jlcxx/jlcxx.hpp>
+#include <jlcxx/stl.hpp>
+#include <typeinfo>
+
+#include <richdem/common/Array2D.hpp>
+#include <richdem/common/constants.hpp>
+#include <richdem/depressions/depression_hierarchy.hpp>
+#include <richdem/misc/misc_methods.hpp>
+
+namespace rd = richdem;
+
+JLCXX_MODULE define_misc_module(jlcxx::Module &mod)
+{
+    mod.method("BucketFillFromEdgesD8", [](const rd::Array2D<double> &check_raster,
+                                           rd::Array2D<rd::dephier::dh_label_t> &set_raster, double check_value, rd::dephier::dh_label_t set_value)
+               { return rd::BucketFillFromEdges<rd::Topology::D8>(check_raster, set_raster, check_value, set_value); });
+}


### PR DESCRIPTION
The following missing functionality of richdem has been added 

- Wrapping of `Array2D<double>(string)` constructor. It can now be called from Julia like this:
```
using richdem
 m = richdem.common.Array2D{Float64}("../../data/clipped_corrected_DSM_N51_W001_V2_50m.tif")
```
- Wrapping of member method `Array2D.setNoData` called from Julia like this:
```
richdem.common.setNoData(m, -9999)
```